### PR TITLE
Develop

### DIFF
--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -9,8 +9,8 @@ $packageArgs = @{
   checksum64     = '1dbc7bafbcc458a628e23316d1b53a9906d0d30dd83673c87f86af1893ee5906'
   checksumType64 = 'sha256'
   softwareName   = 'LM Studio*'
-  silentArgs     = '/S'
-  validExitCodes = @(0)
+  silentArgs     = '/S /quiet'
+  validExitCodes = @(0, 3010, 1641)
 }
 
 Install-ChocolateyPackage @packageArgs

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,22 +1,16 @@
-$ErrorActionPreference = 'Stop';
-$packageName = 'lmstudio'
-$url = 'https://installers.lmstudio.ai/win32/x64/0.3.9-6/LM-Studio-0.3.9-6-x64.exe'
-$installerType = 'exe'
-$checksum = '1dbc7bafbcc458a628e23316d1b53a9906d0d30dd83673c87f86af1893ee5906'
-$checksumType = 'sha256'
-$silentArgs = '/S'
-$validExitCodes = @(0)
+$ErrorActionPreference = 'Stop'
 
-$installPath = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$downloadFile = Join-Path $installPath "$($packageName)Setup.exe"
+$toolsPath = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
-Get-ChocolateyWebFile -PackageName $packageName `
-  -FileFullPath $downloadFile `
-  -Url $url `
-  -Checksum $checksum `
-  -ChecksumType $checksumType
-Install-ChocolateyInstallPackage -PackageName $packageName `
-  -FileType $installerType `
-  -SilentArgs $silentArgs `
-  -File $downloadFile `
-  -ValidExitCodes $validExitCodes
+$packageArgs = @{
+  packageName    = $env:ChocolateyPackageName
+  fileType       = 'EXE'
+  url64          = 'https://installers.lmstudio.ai/win32/x64/0.3.9-6/LM-Studio-0.3.9-6-x64.exe'
+  checksum64     = '1dbc7bafbcc458a628e23316d1b53a9906d0d30dd83673c87f86af1893ee5906'
+  checksumType64 = 'sha256'
+  softwareName   = 'LM Studio*'
+  silentArgs     = '/S'
+  validExitCodes = @(0)
+}
+
+Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
This pull request refactors the `tools/chocolateyInstall.ps1` script to simplify and standardize the installation process for the LM Studio package. The changes include replacing manual download and installation logic with the `Install-ChocolateyPackage` helper function, improving maintainability and consistency.

### Refactoring and standardization:

* Replaced the manual download and installation logic (`Get-ChocolateyWebFile` and `Install-ChocolateyInstallPackage`) with the `Install-ChocolateyPackage` helper function, consolidating package installation into a single, more maintainable block.
* Updated the `$packageArgs` dictionary to include parameters like `url64`, `checksum64`, `checksumType64`, and `silentArgs`, which align with Chocolatey's best practices for defining package metadata.
* Expanded the `validExitCodes` to include `3010` and `1641`, ensuring proper handling of exit codes related to successful installations requiring restarts.

These changes improve the script's readability, reduce redundancy, and adhere to Chocolatey conventions.